### PR TITLE
Stop image from stretching on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <img src="https://raw.githubusercontent.com/Flinesoft/AnyLint/main/Logo.png"
-      width=562 height=115>
+      width=562 />
 </p>
 
 <p align="center">


### PR DESCRIPTION
A weird quirks of GitHub is that mobile pages override custom widths but not custom heights, causing stretching unless you specify width only.

Before;

![D29B911B-B7C9-4275-A0B0-D21AA5E6E91F](https://user-images.githubusercontent.com/464574/77815180-bd311980-708e-11ea-82c3-3109da903ed8.png)

After:

![139501DD-13F2-4589-A09D-196BD0F1065E](https://user-images.githubusercontent.com/464574/77815185-c9b57200-708e-11ea-93db-6c3b98a6347f.png)

