### PR TITLE
Add cache for same search options in file search

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcbaselines/AnyLintTests.xcbaseline/17124E59-2851-436E-BEA7-3FAEFD815A8B.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/AnyLintTests.xcbaseline/17124E59-2851-436E-BEA7-3FAEFD815A8B.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>FilesSearchTests</key>
+		<dict>
+			<key>testPerformanceOfSameSearchOptions()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0252</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/AnyLintTests.xcbaseline/Info.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/AnyLintTests.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>17124E59-2851-436E-BEA7-3FAEFD815A8B</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>8-Core Intel Core i9</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2300</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>16</integer>
+				<key>modelCode</key>
+				<string>MacBookPro15,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64h</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 ### Added
 - None.
 ### Changed
-- None.
+- Hugely improved performance of subsequent file searches with the same combination of `includeFilters` and `excludeFilters`. For example, if 30 checks were sharing the same filters, each file search is now ~8x faster.  
+  Issue: [#20](https://github.com/Flinesoft/AnyLint/issues/20) | PR: [#21](https://github.com/Flinesoft/AnyLint/pull/21) | Author: [Cihat Gündüz](https://github.com/Jeehut)
 ### Deprecated
 - None.
 ### Removed

--- a/Sources/AnyLint/Extensions/FileManagerExt.swift
+++ b/Sources/AnyLint/Extensions/FileManagerExt.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Utility
+
+extension FileManager {
+    /// Moves a file from one path to another, making sure that all directories are created and no files are overwritten.
+    func moveFileSafely(from sourcePath: String, to targetPath: String) throws {
+        guard fileExists(atPath: sourcePath) else {
+            log.message("No file found at \(sourcePath) to move.", level: .error)
+            log.exit(status: .failure)
+            return // only reachable in unit tests
+        }
+
+        guard !fileExists(atPath: targetPath) || sourcePath.lowercased() == targetPath.lowercased() else {
+            log.message("File already exists at target path \(targetPath) – can't move from \(sourcePath).", level: .warning)
+            return
+        }
+
+        let targetParentDirectoryPath = targetPath.parentDirectoryPath
+        if !fileExists(atPath: targetParentDirectoryPath) {
+            try createDirectory(atPath: targetParentDirectoryPath, withIntermediateDirectories: true, attributes: nil)
+        }
+
+        guard fileExistsAndIsDirectory(atPath: targetParentDirectoryPath) else {
+            log.message("Expected \(targetParentDirectoryPath) to be a directory.", level: .error)
+            log.exit(status: .failure)
+            return // only reachable in unit tests
+        }
+
+        if sourcePath.lowercased() == targetPath.lowercased() {
+            // workaround issues on case insensitive file systems
+            let temporaryTargetPath = targetPath + UUID().uuidString
+            try moveItem(atPath: sourcePath, toPath: temporaryTargetPath)
+            try moveItem(atPath: temporaryTargetPath, toPath: targetPath)
+        } else {
+            try moveItem(atPath: sourcePath, toPath: targetPath)
+        }
+
+        FilesSearch.shared.invalidateCache()
+    }
+}

--- a/Sources/AnyLint/FilesSearch.swift
+++ b/Sources/AnyLint/FilesSearch.swift
@@ -20,7 +20,7 @@ public final class FilesSearch {
         cachedFilePaths = [:]
     }
 
-    func allFiles(within path: String, includeFilters: [Regex], excludeFilters: [Regex] = []) -> [String] {
+    func allFiles(within path: String, includeFilters: [Regex], excludeFilters: [Regex] = []) -> [String] { // swiftlint:disable:this function_body_length
         log.message(
             "Start searching for matching files in path \(path) with includeFilters \(includeFilters) and excludeFilters \(excludeFilters) ...",
             level: .debug

--- a/Sources/AnyLint/Lint.swift
+++ b/Sources/AnyLint/Lint.swift
@@ -48,7 +48,7 @@ public enum Lint {
             return
         }
 
-        let filePathsToCheck: [String] = FilesSearch.allFiles(
+        let filePathsToCheck: [String] = FilesSearch.shared.allFiles(
             within: fileManager.currentDirectoryPath,
             includeFilters: includeFilters,
             excludeFilters: excludeFilters
@@ -110,7 +110,7 @@ public enum Lint {
             return
         }
 
-        let filePathsToCheck: [String] = FilesSearch.allFiles(
+        let filePathsToCheck: [String] = FilesSearch.shared.allFiles(
             within: fileManager.currentDirectoryPath,
             includeFilters: includeFilters,
             excludeFilters: excludeFilters

--- a/Sources/Utility/Extensions/FileManagerExt.swift
+++ b/Sources/Utility/Extensions/FileManagerExt.swift
@@ -6,40 +6,6 @@ extension FileManager {
         URL(string: currentDirectoryPath)!
     }
 
-    /// Moves a file from one path to another, making sure that all directories are created and no files are overwritten.
-    public func moveFileSafely(from sourcePath: String, to targetPath: String) throws {
-        guard fileExists(atPath: sourcePath) else {
-            log.message("No file found at \(sourcePath) to move.", level: .error)
-            log.exit(status: .failure)
-            return // only reachable in unit tests
-        }
-
-        guard !fileExists(atPath: targetPath) || sourcePath.lowercased() == targetPath.lowercased() else {
-            log.message("File already exists at target path \(targetPath) – can't move from \(sourcePath).", level: .warning)
-            return
-        }
-
-        let targetParentDirectoryPath = targetPath.parentDirectoryPath
-        if !fileExists(atPath: targetParentDirectoryPath) {
-            try createDirectory(atPath: targetParentDirectoryPath, withIntermediateDirectories: true, attributes: nil)
-        }
-
-        guard fileExistsAndIsDirectory(atPath: targetParentDirectoryPath) else {
-            log.message("Expected \(targetParentDirectoryPath) to be a directory.", level: .error)
-            log.exit(status: .failure)
-            return // only reachable in unit tests
-        }
-
-        if sourcePath.lowercased() == targetPath.lowercased() {
-            // workaround issues on case insensitive file systems
-            let temporaryTargetPath = targetPath + UUID().uuidString
-            try moveItem(atPath: sourcePath, toPath: temporaryTargetPath)
-            try moveItem(atPath: temporaryTargetPath, toPath: targetPath)
-        } else {
-            try moveItem(atPath: sourcePath, toPath: targetPath)
-        }
-    }
-
     /// Checks if a file exists and the given paths and is a directory.
     public func fileExistsAndIsDirectory(atPath path: String) -> Bool {
         var isDirectory: ObjCBool = false

--- a/Sources/Utility/Regex.swift
+++ b/Sources/Utility/Regex.swift
@@ -129,6 +129,7 @@ extension Regex: Hashable {
     /// Manages hashing of the `Regex` instance.
     public func hash(into hasher: inout Hasher) {
         hasher.combine(regularExpression)
+        hasher.combine(options)
     }
 }
 
@@ -186,6 +187,8 @@ extension Regex.Options: CustomStringConvertible {
         return description
     }
 }
+
+extension Regex.Options: Equatable, Hashable {}
 
 // MARK: - Match
 extension Regex {

--- a/Tests/AnyLintTests/FilesSearchTests.swift
+++ b/Tests/AnyLintTests/FilesSearchTests.swift
@@ -17,19 +17,45 @@ final class FilesSearchTests: XCTestCase {
                 (subpath: "Sources/.hidden_dir/unhidden_file", contents: ""),
             ]
         ) { _ in
-            let includeFilterFilePaths = FilesSearch.allFiles(
+            let includeFilterFilePaths = FilesSearch.shared.allFiles(
                 within: FileManager.default.currentDirectoryPath,
                 includeFilters: [try Regex("\(tempDir)/.*")],
                 excludeFilters: []
             )
             XCTAssertEqual(includeFilterFilePaths, ["\(tempDir)/Sources/Hello.swift", "\(tempDir)/Sources/World.swift"])
 
-            let excludeFilterFilePaths = FilesSearch.allFiles(
+            let excludeFilterFilePaths = FilesSearch.shared.allFiles(
                 within: FileManager.default.currentDirectoryPath,
                 includeFilters: [try Regex("\(tempDir)/.*")],
                 excludeFilters: ["World"]
             )
             XCTAssertEqual(excludeFilterFilePaths, ["\(tempDir)/Sources/Hello.swift"])
+        }
+    }
+
+    func testPerformanceOfSameSearchOptions() {
+        let swiftSourcesFilePaths = (0 ... 800).map { (subpath: "Sources/Foo\($0).swift", contents: "Lorem ipsum\ndolor sit amet\n") }
+        let testsFilePaths = (0 ... 400).map { (subpath: "Tests/Foo\($0).swift", contents: "Lorem ipsum\ndolor sit amet\n") }
+        let storyboardSourcesFilePaths = (0 ... 300).map { (subpath: "Sources/Foo\($0).storyboard", contents: "Lorem ipsum\ndolor sit amet\n") }
+
+        withTemporaryFiles(swiftSourcesFilePaths + testsFilePaths + storyboardSourcesFilePaths) { _ in
+            let fileSearchCode: () -> [String] = {
+                FilesSearch.shared.allFiles(
+                    within: FileManager.default.currentDirectoryPath,
+                    includeFilters: [try! Regex(#"\#(self.tempDir)/Sources/Foo.*"#)],
+                    excludeFilters: [try! Regex(#"\#(self.tempDir)/.*\.storyboard"#)]
+                )
+            }
+
+
+            measure {
+                // first run
+                XCTAssertEqual(Set(fileSearchCode()), Set(swiftSourcesFilePaths.map { "\(tempDir)/\($0.subpath)" }))
+
+                // subsequent runs (should be much faster)
+                XCTAssertEqual(Set(fileSearchCode()), Set(swiftSourcesFilePaths.map { "\(tempDir)/\($0.subpath)" }))
+                XCTAssertEqual(Set(fileSearchCode()), Set(swiftSourcesFilePaths.map { "\(tempDir)/\($0.subpath)" }))
+            }
         }
     }
 }

--- a/Tests/AnyLintTests/FilesSearchTests.swift
+++ b/Tests/AnyLintTests/FilesSearchTests.swift
@@ -2,6 +2,8 @@
 @testable import Utility
 import XCTest
 
+// swiftlint:disable force_try
+
 final class FilesSearchTests: XCTestCase {
     override func setUp() {
         log = Logger(outputType: .test)
@@ -46,7 +48,6 @@ final class FilesSearchTests: XCTestCase {
                     excludeFilters: [try! Regex(#"\#(self.tempDir)/.*\.storyboard"#)]
                 )
             }
-
 
             measure {
                 // first run

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -41,7 +41,8 @@ extension FilePathsCheckerTests {
 
 extension FilesSearchTests {
     static var allTests: [(String, (FilesSearchTests) -> () throws -> Void)] = [
-        ("testAllFilesWithinPath", testAllFilesWithinPath)
+        ("testAllFilesWithinPath", testAllFilesWithinPath),
+        ("testPerformanceOfSameSearchOptions", testPerformanceOfSameSearchOptions)
     ]
 }
 


### PR DESCRIPTION
Fixes #20.

I investigated and we already skip all subdirectories when any of the `excludeFilters` applies or it's a hidden directory. The `includeFilters` shortcut optimization is hard to implement, as the combination of all `includeFilters` is used per check and they might differ. Instead, I opted for caching if the file search combination is the same.