### PR TITLE
No violation when match equals to autoCorrectReplacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ If needed, pluralize to `Tasks`, `PRs` or `Authors` and list multiple entries se
 ### Added
 - None.
 ### Changed
-- None.
+- When a given `autoCorrectReplacement` on the `checkFileContents` method leads to no changes, the matched string of the given `regex` is considered to be already correct, thus no violation is reported anymore.  
+  Issue: [#26](https://github.com/Flinesoft/AnyLint/issues/26) | PR: [#28](https://github.com/Flinesoft/AnyLint/pull/28) | Author: [Cihat Gündüz](https://github.com/Jeehut)
 ### Deprecated
 - None.
 ### Removed

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "AnyLint",
     products: [
-        .library(name: "AnyLint", targets: ["AnyLint"]),
+        .library(name: "AnyLint", targets: ["AnyLint", "Utility"]),
         .executable(name: "anylint", targets: ["AnyLintCLI"]),
     ],
     dependencies: [

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Many parameters in the above mentioned lint check methods are of `Regex` type. A
   let regexWithOptions: Regex = ["key": #"foo|bar"#, "num": "[0-9]+", #"\"#: "im"] // => /(?<key>foo|bar)(?<num>[0-9]+)/im
   ```
 
-Note that we recommend using [raw strings](https://www.hackingwithswift.com/articles/162/how-to-use-raw-strings-in-swift) (`#"foo"#` instead of `"foo"`) for all regexes to get rid of double escaping backslashes (e.g. `\\s` becomes `\s`). This also allows for testing regexes in online regex editors like [Rubular](https://rubular.com/) first and then copy & pasting from them without any additional escaping.
+Note that we recommend using [raw strings](https://www.hackingwithswift.com/articles/162/how-to-use-raw-strings-in-swift) (`#"foo"#` instead of `"foo"`) for all regexes to get rid of double escaping backslashes (e.g. `\\s` becomes `\s`). This also allows for testing regexes in online regex editors like [Rubular](https://rubular.com/) first and then copy & pasting from them without any additional escaping (except for `{` & `}`, replace with `\{` & `\}`).
 
 <details>
 <summary>Regex Options</summary>

--- a/README.md
+++ b/README.md
@@ -380,31 +380,47 @@ AnyLint allows you to do any kind of lint checks (thus its name) as it gives you
 
 Note that the `Violation` type just holds some additional information on the file, matched string, location in the file and applied autocorrection and that all these fields are optional. It is a simple struct used by the AnyLint reporter for more detailed output, no logic attached. The only required field is the `CheckInfo` object which caused the violation.
 
-If you want to use regexes in your custom code, you can learn more about how you can match strings with a `Regex` object on [the HandySwift docs](https://github.com/Flinesoft/AnyLint/blob/main/Sources/Utility/Regex.swift) (the project, the class was taken from) or read the [code documentation comments](https://github.com/Flinesoft/AnyLint/blob/main/Sources/Utility/Regex.swift).
+If you want to use regexes in your custom code, you can learn more about how you can match strings with a `Regex` object on [the HandySwift docs](https://github.com/Flinesoft/HandySwift#regex) (the project, the class was taken from) or read the [code documentation comments](https://github.com/Flinesoft/AnyLint/blob/main/Sources/Utility/Regex.swift).
 
 When using the `customCheck`, you might want to also include some Swift packages for [easier file handling](https://github.com/JohnSundell/Files) or [running shell commands](https://github.com/JohnSundell/ShellOut). You can do so by adding them at the top of the file like so:
-
-> TODO: Improve the below code example with something more useful & realistic.
 
 ```swift
 #!/usr/local/bin/swift-sh
 import AnyLint // @Flinesoft
-import Files // @JohnSundell
 import ShellOut // @JohnSundell
 
 Lint.logSummaryAndExit(arguments: CommandLine.arguments) {
-    // MARK: echo
-    try Lint.customCheck(checkInfo: "Echo: Always say hello to the world.") { checkInfo in
+    // MARK: - Variables
+    let projectName: String = "AnyLint"
+
+    // MARK: - Checks 
+    // MARK: LinuxMainUpToDate
+    try Lint.customCheck(checkInfo: "LinuxMainUpToDate: The tests in Tests/LinuxMain.swift should be up-to-date.") { checkInfo in
         var violations: [Violation] = []
 
-        // use ShellOut package
-        let output = try shellOut(to: "echo", arguments: ["Hello world"])
-        // ...
+        let linuxMainFilePath = "Tests/LinuxMain.swift"
+        let linuxMainContentsBeforeRegeneration = try! String(contentsOfFile: linuxMainFilePath)
 
-        // use Files package
-        try Folder(path: "MyFolder").files.forEach { file in
-            // ...
-            violations.append(Violation(checkInfo: checkInfo))
+        let sourceryDirPath = ".sourcery"
+        try! shellOut(to: "sourcery", arguments: ["--sources", "Tests/\(projectName)Tests", "--templates", "\(sourceryDirPath)/LinuxMain.stencil", "--output", sourceryDirPath])
+        
+        let generatedLinuxMainFilePath = "\(sourceryDirPath)/LinuxMain.generated.swift"
+        let linuxMainContentsAfterRegeneration = try! String(contentsOfFile: generatedLinuxMainFilePath)
+
+        // move generated file to LinuxMain path to update its contents
+        try! shellOut(to: "mv", arguments: [generatedLinuxMainFilePath, linuxMainFilePath])
+
+        if linuxMainContentsBeforeRegeneration != linuxMainContentsAfterRegeneration {
+            violations.append(
+                Violation(
+                    checkInfo: checkInfo,
+                    filePath: linuxMainFilePath,
+                    appliedAutoCorrection: AutoCorrection(
+                        before: linuxMainContentsBeforeRegeneration,
+                        after: linuxMainContentsAfterRegeneration
+                    )
+                )
+            )
         }
 
         return violations

--- a/Sources/Utility/Extensions/StringExt.swift
+++ b/Sources/Utility/Extensions/StringExt.swift
@@ -24,12 +24,8 @@ extension String {
 
     /// Returns the parent directory path.
     public var parentDirectoryPath: String {
-        guard let url = URL(string: self) else {
-            log.message("Could not convert path '\(self)' to type URL.", level: .error)
-            log.exit(status: .failure)
-            return "" // only reachable in unit tests
-        }
-
+        let url = URL(fileURLWithPath: self)
+        guard url.pathComponents.count > 1 else { return fileManager.currentDirectoryPath }
         return url.deletingLastPathComponent().absoluteString
     }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.18.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 @testable import AnyLintTests
@@ -29,7 +29,8 @@ extension FileContentsCheckerTests {
     static var allTests: [(String, (FileContentsCheckerTests) -> () throws -> Void)] = [
         ("testPerformCheck", testPerformCheck),
         ("testSkipInFile", testSkipInFile),
-        ("testSkipHere", testSkipHere)
+        ("testSkipHere", testSkipHere),
+        ("testSkipIfEqualsToAutocorrectReplacement", testSkipIfEqualsToAutocorrectReplacement)
     ]
 }
 

--- a/lint.swift
+++ b/lint.swift
@@ -1,5 +1,7 @@
 #!/usr/local/bin/swift-sh
 import AnyLint // .
+import Utility
+import ShellOut // @JohnSundell
 
 try Lint.logSummaryAndExit(arguments: CommandLine.arguments) {
     // MARK: - Variables
@@ -7,6 +9,7 @@ try Lint.logSummaryAndExit(arguments: CommandLine.arguments) {
     let swiftTestFiles: Regex = #"Tests/.*\.swift"#
     let readmeFile: Regex = #"README\.md"#
     let changelogFile: Regex = #"^CHANGELOG\.md$"#
+    let projectName: String = "AnyLint"
 
     // MARK: - Checks
     // MARK: Changelog
@@ -436,6 +439,49 @@ try Lint.logSummaryAndExit(arguments: CommandLine.arguments) {
             ["before": "call(x: (viewModel?.username)!)", "after": "call(x: viewModel!.username)"],
         ]
     )
+
+    // MARK: LinuxMainUpToDate
+    try Lint.customCheck(checkInfo: "LinuxMainUpToDate: The tests in Tests/LinuxMain.swift should be up-to-date.") { checkInfo in
+        var violations: [Violation] = []
+
+        let linuxMainFilePath = "Tests/LinuxMain.swift"
+        let linuxMainContentsBeforeRegeneration = try! String(contentsOfFile: linuxMainFilePath)
+
+        let sourceryDirPath = ".sourcery"
+        let testsDirPath = "Tests/\(projectName)Tests"
+        let stencilFilePath = "\(sourceryDirPath)/LinuxMain.stencil"
+        let generatedLinuxMainFilePath = "\(sourceryDirPath)/LinuxMain.generated.swift"
+
+        let sourceryInstallPath = try? shellOut(to: "which", arguments: ["sourcery"])
+        guard sourceryInstallPath != nil else {
+            log.message(
+                "Skipped custom check \(checkInfo) – requires Sourcery to be installed, download from: https://github.com/krzysztofzablocki/Sourcery",
+                level: .warning
+            )
+            return []
+        }
+
+        try! shellOut(to: "sourcery", arguments: ["--sources", testsDirPath, "--templates", stencilFilePath, "--output", sourceryDirPath])
+        let linuxMainContentsAfterRegeneration = try! String(contentsOfFile: generatedLinuxMainFilePath)
+
+        // move generated file to LinuxMain path to update its contents
+        try! shellOut(to: "mv", arguments: [generatedLinuxMainFilePath, linuxMainFilePath])
+
+        if linuxMainContentsBeforeRegeneration != linuxMainContentsAfterRegeneration {
+            violations.append(
+                Violation(
+                    checkInfo: checkInfo,
+                    filePath: linuxMainFilePath,
+                    appliedAutoCorrection: AutoCorrection(
+                        before: linuxMainContentsBeforeRegeneration,
+                        after: linuxMainContentsAfterRegeneration
+                    )
+                )
+            )
+        }
+
+        return violations
+    }
 
     // MARK: Logger
     try Lint.checkFileContents(


### PR DESCRIPTION
Fixes #26.

## Proposed Changes

  - Adds a new check to ensure running AnyLint as a pre-commit hook updates LinuxMain.swift before committing.
  - Updates README example for customCheck with real example (using above LinuxMain check).
  - Make sure that no violations are reported if a given `autoCorrectReplacement` leads to no changes, meaning the matched string is already correct. (See #26)
